### PR TITLE
fix: Correct list_provider_fields() dictionary lookup

### DIFF
--- a/mgit/config/providers.py
+++ b/mgit/config/providers.py
@@ -13,6 +13,13 @@ from mgit.config.manager import get_config_value, load_config_file, save_config_
 from mgit.providers.base import AuthMethod
 
 
+# Provider constants for easier access
+PROVIDER_AZUREDEVOPS = "azuredevops"
+PROVIDER_GITHUB = "github"
+PROVIDER_BITBUCKET = "bitbucket"
+SUPPORTED_PROVIDERS = [PROVIDER_AZUREDEVOPS, PROVIDER_GITHUB, PROVIDER_BITBUCKET]
+
+
 class ProviderType(Enum):
     """Supported provider types."""
     AZURE_DEVOPS = "azuredevops"
@@ -407,3 +414,74 @@ def migrate_legacy_config() -> None:
     if updates:
         config.update(updates)
         save_config_file(config)
+
+
+def get_provider_defaults(provider: str) -> Dict[str, Any]:
+    """Get default configuration values for a provider.
+    
+    Args:
+        provider: Provider name
+        
+    Returns:
+        Dictionary of default configuration values
+        
+    Raises:
+        ValueError: If provider is not supported
+    """
+    # Validate provider
+    try:
+        provider_type = ProviderType(provider.lower())
+    except ValueError:
+        raise ValueError(
+            f"Unsupported provider: {provider}. "
+            f"Supported providers: {', '.join([p.value for p in ProviderType])}"
+        )
+    
+    return PROVIDER_DEFAULTS[provider_type].copy()
+
+
+def list_provider_fields(provider: str) -> List[str]:
+    """List all configuration fields for a provider.
+    
+    This is an alias for list_provider_config_keys() to match the expected API.
+    
+    Args:
+        provider: Provider name
+        
+    Returns:
+        List of configuration fields
+        
+    Raises:
+        ValueError: If provider is not supported
+    """
+    return list_provider_config_keys(provider)
+
+
+def clear_provider_config(provider: str) -> None:
+    """Clear a provider's configuration.
+    
+    This is an alias for reset_provider_config() to match the expected API.
+    
+    Args:
+        provider: Provider name
+        
+    Raises:
+        ValueError: If provider is not supported
+    """
+    reset_provider_config(provider)
+
+
+def is_provider_configured(provider: str) -> bool:
+    """Check if a provider has all required configuration.
+    
+    Args:
+        provider: Provider name
+        
+    Returns:
+        True if provider is fully configured, False otherwise
+        
+    Raises:
+        ValueError: If provider is not supported
+    """
+    errors = validate_provider_config(provider)
+    return len(errors) == 0


### PR DESCRIPTION
## Summary
- Fixes ImportError for `list_provider_fields` function that was missing from `mgit.config.providers` 
- Adds helper functions and constants to the providers module

## Changes
- Added `list_provider_fields()` function as alias to `list_provider_config_keys()`
- Added `clear_provider_config()` function as alias to `reset_provider_config()`
- Added `is_provider_configured()` function to check if provider is fully configured
- Added `get_provider_defaults()` function to get default values
- Added provider constants for easier access

## Test Plan
- [ ] Verify `from mgit.config.providers import list_provider_fields` works without error
- [ ] Test provider configuration commands work correctly
- [ ] Ensure no regressions in existing functionality

Fixes #302

🤖 Generated with [Claude Code](https://claude.ai/code)