### PR TITLE
Fix notify job termination

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -711,3 +711,4 @@ jobs:
         echo "docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest" >> $GITHUB_STEP_SUMMARY
         echo "docker run --rm ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest --help" >> $GITHUB_STEP_SUMMARY
         echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+    # End of notify job


### PR DESCRIPTION
## Summary
- fix newline at end of release workflow and mark the end of the notify job

## Testing
- `yamllint .github/workflows/release.yml` *(fails: command not found)*
- `act -n -j notify` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683d468f14948327aa39484e7c284731