### PR TITLE
Fix safety project path

### DIFF
--- a/.safety-project.ini
+++ b/.safety-project.ini
@@ -1,5 +1,4 @@
 [project]
 id = mgit
-url = /codebases/mgit/findings
 name = mgit
 


### PR DESCRIPTION
## Summary
- remove the url path from `.safety-project.ini`

## Testing
- `poetry run poe format-check` *(fails: 11 files would be reformatted)*
- `poetry run poe lint` *(fails: 54 errors)*
- `poetry run poe test` *(fails: 6 failed, 80 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6881cc35fc3083278037ba3a12bea6b9