### PR TITLE
Add security policy docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -687,7 +687,7 @@ The automated workflow will:
 
 ## Security
 
-For security vulnerabilities, see our [Security Policy](SECURITY.md).
+Please report vulnerabilities using the process outlined in our [Security Policy](SECURITY.md).
 
 **Security features include:**
 - Comprehensive threat model and risk analysis

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,15 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please report suspected vulnerabilities by opening a [GitHub security advisory](https://github.com/AeyeOps/mgit/security/advisories/new) or by emailing **security@aeyeops.com**. Include as much detail as possible so we can reproduce the issue.
+
+We request that you do not publicly disclose the vulnerability until we have had a chance to address it.
+
+## Security Procedures
+
+- We review all reports promptly and will work with you on a timeline for disclosure.
+- Fixes will be prioritized and released as soon as practical.
+- Security-related changes are documented in the release notes and CHANGELOG.
+
+Thank you for helping keep mgit secure!

--- a/docs/README.md
+++ b/docs/README.md
@@ -152,7 +152,7 @@ mgit status ./repos --all
 We welcome contributions to both code and documentation!
 
 - **[Contributing Guide](../CONTRIBUTING.md)** - How to contribute
-- **[Security Policy](../SECURITY.md)** - Report security issues
+- **[Security Policy](../SECURITY.md)** - How to report vulnerabilities and our procedures
 - **[Code of Conduct](../CODE_OF_CONDUCT.md)** - Community guidelines
 
 ### Improving Documentation


### PR DESCRIPTION
## Summary
- add SECURITY.md policy with contact info
- update README to reference new Security Policy
- document security policy link in docs

## Testing
- `pytest -q tests/unit` *(fails: ModuleNotFoundError: No module named 'typer')*

------
https://chatgpt.com/codex/tasks/task_e_6881cc38474483279ab44bdc43736ec4