### PR TITLE
Fix mgit package data and dependencies

### DIFF
--- a/mgit/__init__.py
+++ b/mgit/__init__.py
@@ -1,20 +1,42 @@
-"""
-mgit - Multi-provider Git management tool
+"""mgit - Multi-provider Git management tool.
+
+The ``pyproject.toml`` file is packaged so we can read the
+version directly when installed as a wheel or bundled with
+PyInstaller.
 """
 
 import sys
+from importlib import metadata
 from pathlib import Path
 
-# Read version from pyproject.toml - it's always there
-if getattr(sys, "frozen", False):
-    # PyInstaller bundle - pyproject.toml is in the extracted directory
-    pyproject_path = Path(sys._MEIPASS) / "pyproject.toml"
-else:
-    # Normal execution
-    pyproject_path = Path(__file__).parent.parent / "pyproject.toml"
 
-with open(pyproject_path, "r") as f:
-    for line in f:
-        if line.strip().startswith('version = "'):
-            __version__ = line.split('"')[1]
-            break
+def _read_version_from_pyproject(path: Path) -> str:
+    """Fallback for obtaining the version from a local pyproject file."""
+    try:
+        with path.open("r") as f:
+            for line in f:
+                if line.strip().startswith('version = "'):
+                    return line.split('"')[1]
+    except FileNotFoundError:
+        pass
+    return "unknown"
+
+
+def _get_version() -> str:
+    """Return the package version, preferring the bundled pyproject."""
+    if getattr(sys, "frozen", False):
+        pyproject_path = Path(sys._MEIPASS) / "pyproject.toml"
+    else:
+        pyproject_path = Path(__file__).parent.parent / "pyproject.toml"
+
+    version = _read_version_from_pyproject(pyproject_path)
+    if version != "unknown":
+        return version
+
+    try:
+        return metadata.version("mgit")
+    except metadata.PackageNotFoundError:
+        return "unknown"
+
+
+__version__ = _get_version()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ authors = ["Steve Antonakakis <steve.antonakakis@gmail.com>"]
 readme = "README.md"
 license = "MIT"
 packages = [{include = "mgit"}]
+include = ["pyproject.toml"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
@@ -30,6 +31,8 @@ typer = "^0.9.0"
 pyyaml = "^6.0"
 "ruamel.yaml" = "^0.18.0"
 cryptography = ">=44.0.1"
+azure-core = ">=1.24.0"
+msrest = ">=0.7.1,<0.8.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.0.0"


### PR DESCRIPTION
## Summary
- include `pyproject.toml` in the wheel
- expose missing `azure-core` and `msrest` dependencies
- load version from the bundled pyproject before falling back to `importlib.metadata`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'typer')*

------
https://chatgpt.com/codex/tasks/task_e_688a92f1ced483278485ca3be14eaec9